### PR TITLE
Fix image pixel indexing and UI typos

### DIFF
--- a/src/components/ImageEditor.tsx
+++ b/src/components/ImageEditor.tsx
@@ -71,7 +71,7 @@ export const ImageEditor = (props: ImageViewProps) => {
             ctx.fillStyle = 'red'; // Up filter
             break;
           case PngImageFilterType.Average:
-            ctx.fillStyle = 'yelow'; // Average filter
+            ctx.fillStyle = 'yellow'; // Average filter
             break;
           case PngImageFilterType.Paeth:
             ctx.fillStyle = 'green'; // Paeth filter

--- a/src/components/file-loader/FileLoader.tsx
+++ b/src/components/file-loader/FileLoader.tsx
@@ -26,7 +26,7 @@ export const FileLoader = (props: FileLoaderProps) => {
   return (
     <div className={(props.className || "") + " row"}>
       <div className="col-auto">
-        <Form.Label className="col-form-label" htmlfor={id}>PNG 画像を選択:</Form.Label>
+        <Form.Label className="col-form-label" htmlFor={id}>PNG 画像を選択:</Form.Label>
       </div>
       <div className="col-auto">
         <Form.Control id={id} type="file" onChange={onchange} accept="image/png"/>

--- a/src/logics/png-image.ts
+++ b/src/logics/png-image.ts
@@ -30,11 +30,11 @@ export class PngImage {
     let offset = 0;
     const byteOfPixel = pixelByte(this.pngData.IHDR.colorType)
     if (byteOfPixel === 0) throw new Error("Invalid color type");
-    const scanlineLnength = this.pngData.IHDR.width * pixelByte(this.pngData.IHDR.colorType) + 1;
+    const scanlineLength = this.pngData.IHDR.width * byteOfPixel + 1;
     while (offset < imageData.length) {
-      const scanline = imageData.slice(offset, offset + scanlineLnength);
+      const scanline = imageData.slice(offset, offset + scanlineLength);
       this.imageData.push(new PngImageScanline(scanline));
-      offset += scanlineLnength;
+      offset += scanlineLength;
     }
   }
 
@@ -99,7 +99,8 @@ export class PngImage {
 
   public getRawPixel(x: number, y: number) {
     const scanline = this.imageData[y];
-    const pixel = scanline.data[x * this.pngData.IHDR.bitDepth / 8 | 0];
+    const pixelSize = pixelByte(this.pngData.IHDR.colorType);
+    const pixel = scanline.data[x * pixelSize];
     return pixel;
   }
 
@@ -123,10 +124,8 @@ export class PngImage {
         break;
       case 4:
         // Grayscale with alpha
-        scanline.data[x * 4 + 0] = (pixel as number[])[0];
-        scanline.data[x * 4 + 1] = (pixel as number[])[1];
-        scanline.data[x * 4 + 2] = (pixel as number[])[2];
-        scanline.data[x * 4 + 3] = (pixel as number[])[3];
+        scanline.data[x * 2 + 0] = (pixel as number[])[0];
+        scanline.data[x * 2 + 1] = (pixel as number[])[1];
         break;
       case 6:
         // RGB with alpha


### PR DESCRIPTION
## Summary
- fix label attribute typo so React label works
- correct filter color spelling
- fix scanline length and pixel indexing logic
- handle grayscale+alpha pixels correctly

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_6851454ae730832abe99ec88da5ea81e