### PR TITLE
Add Jest testing setup

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,9 @@
+import type { JestConfigWithTsJest } from 'ts-jest';
+
+const config: JestConfigWithTsJest = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/?(*.)+(test).[tj]s?(x)']
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "index.js",
   "scripts": {
     "dev": "cross-env NODE_ENV=\"development\" webpack serve",
-    "build": "cross-env NODE_ENV=\"production\" webpack build"
+    "build": "cross-env NODE_ENV=\"production\" webpack build",
+    "test": "jest"
   },
   "author": "",
   "license": "ISC",
@@ -30,7 +31,10 @@
     "typescript": "^5.7.3",
     "webpack": "^5.97.1",
     "webpack-cli": "^6.0.1",
-    "webpack-dev-server": "^5.2.0"
+    "webpack-dev-server": "^5.2.0",
+    "@types/jest": "^29.5.5",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1"
   },
   "dependencies": {
     "bootstrap": "^5.3.3",

--- a/src/logics/__tests__/crc32.test.ts
+++ b/src/logics/__tests__/crc32.test.ts
@@ -1,0 +1,6 @@
+import { crc32 } from '../crc32';
+
+test('crc32 of IEND', () => {
+  const value = crc32(new Uint8Array([0x49, 0x45, 0x4e, 0x44])) >>> 0;
+  expect(value).toBe(0xae426082);
+});


### PR DESCRIPTION
## Summary
- set up Jest with ts-jest for running TypeScript tests
- add a simple crc32 test

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68517b401c9c832aaa9a0336eb46c25a