### PR TITLE
Add ESLint and Prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -3,7 +3,7 @@ module.exports = [
     files: ['**/*.{ts,tsx}'],
     ignores: ['node_modules/**', 'dist/**'],
     languageOptions: {
-      parser: '@typescript-eslint/parser',
+      parser: require('@typescript-eslint/parser'),
       parserOptions: {
         ecmaVersion: 'latest',
         sourceType: 'module',

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,0 +1,29 @@
+module.exports = [
+  {
+    files: ['**/*.{ts,tsx}'],
+    ignores: ['node_modules/**', 'dist/**'],
+    languageOptions: {
+      parser: '@typescript-eslint/parser',
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': require('@typescript-eslint/eslint-plugin'),
+      react: require('eslint-plugin-react'),
+      prettier: require('eslint-plugin-prettier'),
+    },
+    settings: {
+      react: {
+        version: 'detect',
+      },
+    },
+    extends: [
+      'eslint:recommended',
+      'plugin:@typescript-eslint/recommended',
+      'plugin:react/recommended',
+      'plugin:prettier/recommended',
+    ],
+  },
+];

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@types/jest": "^29.5.5",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
-    "eslint": "^9.0.0",
+    "eslint": "^8.56.0",
     "eslint-plugin-react": "^7.33.2",
     "@typescript-eslint/parser": "^7.0.0",
     "@typescript-eslint/eslint-plugin": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "cross-env NODE_ENV=\"development\" webpack serve",
     "build": "cross-env NODE_ENV=\"production\" webpack build",
-    "test": "jest"
+    "test": "jest",
+    "lint": "eslint \"src/**/*.{ts,tsx}\""
   },
   "author": "",
   "license": "ISC",
@@ -34,7 +35,14 @@
     "webpack-dev-server": "^5.2.0",
     "@types/jest": "^29.5.5",
     "jest": "^29.7.0",
-    "ts-jest": "^29.1.1"
+    "ts-jest": "^29.1.1",
+    "eslint": "^9.0.0",
+    "eslint-plugin-react": "^7.33.2",
+    "@typescript-eslint/parser": "^7.0.0",
+    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "prettier": "^3.5.3",
+    "eslint-plugin-prettier": "^5.1.3",
+    "eslint-config-prettier": "^9.1.0"
   },
   "dependencies": {
     "bootstrap": "^5.3.3",


### PR DESCRIPTION
## Summary
- add ESLint/Prettier configs
- configure lint script

## Testing
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/eslint-plugin')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685185895cd4832abfb69925f90382a0